### PR TITLE
Improvements: gitignore, Device Names as sources, Dry Run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+config.py
+venv/
+env/
+__pycache__/

--- a/config.py.example
+++ b/config.py.example
@@ -11,3 +11,4 @@ DRY_RUN = True
 
 SOURCE_IP = True
 SOURCE_DEVICE = True
+SOURCE_VM = True

--- a/config.py.example
+++ b/config.py.example
@@ -6,3 +6,8 @@ PDNS_KEY = ""
 
 FORWARD_ZONES = ["local"]
 REVERSE_ZONES = [{"zone": "10.10.10.in-addr.arpa.", "prefix": "10.10.10/24"}]
+
+DRY_RUN = True
+
+SOURCE_IP = True
+SOURCE_DEVICE = True

--- a/netbox-powerdns-sync.py
+++ b/netbox-powerdns-sync.py
@@ -9,7 +9,7 @@ import pynetbox
 
 from config import NB_URL, NB_TOKEN, PDNS_API_URL, PDNS_KEY
 from config import FORWARD_ZONES, REVERSE_ZONES, DRY_RUN
-from config import SOURCE_DEVICE, SOURCE_IP
+from config import SOURCE_DEVICE, SOURCE_IP, SOURCE_VM
 
 nb = pynetbox.api(NB_URL, token=NB_TOKEN)
 
@@ -64,6 +64,18 @@ for forward_zone in FORWARD_ZONES:
                     forward_zone_canonical
                 ))
 
+    if SOURCE_VM:
+        for d in nb.virtualization.virtual_machines.filter(name__ic=forward_zone):
+            if d.primary_ip4:
+                host_ips.append((d.name+".",
+                    "A",
+                    re.sub("/[0-9]*", "", str(d.primary_ip4)),
+                    forward_zone_canonical))
+            if d.primary_ip6:
+                host_ips.append((d.name+".",
+                    "AAAA",
+                    re.sub("/[0-9]*", "", str(d.primary_ip6)),
+                    forward_zone_canonical))
     # get zone forward_zone_canonical form PowerDNS
     zone = pdns.get_zone(forward_zone_canonical)
 

--- a/netbox-powerdns-sync.py
+++ b/netbox-powerdns-sync.py
@@ -47,7 +47,7 @@ for forward_zone in FORWARD_ZONES:
         nb_devices = nb.dcim.devices.filter(name__iew=forward_zone)
 
         # assemble list with tupels containing the canonical name, the record
-        # type and the IP address of the device without the subnet
+        # type and the IP addresses without the subnet of the device
         for nb_device in nb_devices:
             if nb_device.primary_ip4:
                 host_ips.append((
@@ -64,18 +64,30 @@ for forward_zone in FORWARD_ZONES:
                     forward_zone_canonical
                 ))
 
+    # Source VM: Create domains based on the name of VMs
     if SOURCE_VM:
-        for d in nb.virtualization.virtual_machines.filter(name__ic=forward_zone):
-            if d.primary_ip4:
-                host_ips.append((d.name+".",
+        # get VMs with name ending in forward_zone from NetBox
+        nb_vms = nb.virtualization.virtual_machines.filter(
+            name__iew=forward_zone)
+
+        # assemble a list with tupels containing the canonical name, the record
+        # type and the primary IP addresses without the subnet of the VM
+        for nb_vm in nb_vms:
+            if nb_vm.primary_ip4:
+                host_ips.append((
+                    nb_vm.name+".",
                     "A",
-                    re.sub("/[0-9]*", "", str(d.primary_ip4)),
-                    forward_zone_canonical))
-            if d.primary_ip6:
-                host_ips.append((d.name+".",
+                    re.sub("/[0-9]*", "", str(nb_vm.primary_ip4)),
+                    forward_zone_canonical
+                ))
+            if nb_vm.primary_ip6:
+                host_ips.append((
+                    nb_vm.name+".",
                     "AAAA",
-                    re.sub("/[0-9]*", "", str(d.primary_ip6)),
-                    forward_zone_canonical))
+                    re.sub("/[0-9]*", "", str(nb_vm.primary_ip6)),
+                    forward_zone_canonical
+                ))
+
     # get zone forward_zone_canonical form PowerDNS
     zone = pdns.get_zone(forward_zone_canonical)
 

--- a/netbox-powerdns-sync.py
+++ b/netbox-powerdns-sync.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
+import ipaddress
+import re
+import sys
+
 import powerdns
 import pynetbox
-import re
-import ipaddress
 
 from config import NB_URL, NB_TOKEN, PDNS_API_URL, PDNS_KEY
 from config import FORWARD_ZONES, REVERSE_ZONES, DRY_RUN
@@ -11,7 +13,8 @@ from config import SOURCE_DEVICE, SOURCE_IP
 
 nb = pynetbox.api(NB_URL, token=NB_TOKEN)
 
-pdns_api_client = powerdns.PDNSApiClient(api_endpoint=PDNS_API_URL, api_key=PDNS_KEY)
+pdns_api_client = powerdns.PDNSApiClient(api_endpoint=PDNS_API_URL,
+                                         api_key=PDNS_KEY)
 pdns = powerdns.PDNSEndpoint(pdns_api_client).servers[0]
 
 host_ips = []
@@ -19,36 +22,47 @@ record_ips = []
 for forward_zone in FORWARD_ZONES:
     forward_zone_canonical = forward_zone+"."
 
-    # Source IP: Create domains based on domain attached directly to IPs
+    # Source IP: Create domains based on DNS name attached to IPs
     if SOURCE_IP:
         # get IPs with DNS name ending in forward_zone from NetBox
         nb_ips = nb.ipam.ip_addresses.filter(dns_name__iew=forward_zone)
 
-        # assemble list with tupels containing the canonical name, the record type
-        # and the IP address without the subnet from NetBox IPs
+        # assemble list with tupels containing the canonical name, the record
+        # type and the IP address without the subnet from NetBox IPs
         for nb_ip in nb_ips:
             if nb_ip.family.value == 6:
                 type = "AAAA"
             else:
                 type = "A"
-            host_ips.append((nb_ip.dns_name+".",
-                            type,
-                            re.sub("/[0-9]*", "", str(nb_ip)),
-                            forward_zone_canonical))
+            host_ips.append((
+                nb_ip.dns_name+".",
+                type,
+                re.sub("/[0-9]*", "", str(nb_ip)),
+                forward_zone_canonical
+            ))
 
-    # if enabled, iterate over all devices and set their primary IPs    
+    # Source device: Create domains based on the name of devices
     if SOURCE_DEVICE:
-        for d in nb.dcim.devices.filter(name__ic=forward_zone):
-            if d.primary_ip4:
-                host_ips.append((d.name+".",
+        # get devices with name ending in forward_zone from NetBox
+        nb_devices = nb.dcim.devices.filter(name__iew=forward_zone)
+
+        # assemble list with tupels containing the canonical name, the record
+        # type and the IP address of the device without the subnet
+        for nb_device in nb_devices:
+            if nb_device.primary_ip4:
+                host_ips.append((
+                    nb_device.name+".",
                     "A",
-                    re.sub("/[0-9]*", "", str(d.primary_ip4)),
-                    forward_zone_canonical))
-            if d.primary_ip6:
-                host_ips.append((d.name+".",
+                    re.sub("/[0-9]*", "", str(nb_device.primary_ip4)),
+                    forward_zone_canonical
+                ))
+            if nb_device.primary_ip6:
+                host_ips.append((
+                    nb_device.name+".",
                     "AAAA",
-                    re.sub("/[0-9]*", "", str(d.primary_ip6)),
-                    forward_zone_canonical))
+                    re.sub("/[0-9]*", "", str(nb_device.primary_ip6)),
+                    forward_zone_canonical
+                ))
 
     # get zone forward_zone_canonical form PowerDNS
     zone = pdns.get_zone(forward_zone_canonical)
@@ -119,29 +133,33 @@ for record in to_delete:
 
 print("----")
 
-if DRY_RUN == False:
-    for record in to_create:
-        print("Creating", record)
-        zone = pdns.get_zone(record[3])
-        zone.create_records([
-                            powerdns.RRSet(record[0],
-                                        record[1],
-                                        [(record[2], False)],
-                                        comments=[powerdns.Comment("NetBox")])
-                            ])
-
-    print("----")
-
-    for record in to_delete:
-        print("Deleting", record)
-        zone = pdns.get_zone(record[3])
-        zone.delete_records([
-                            powerdns.RRSet(record[0],
-                                        record[1],
-                                        [(record[2], False)],
-                                        comments=[powerdns.Comment("NetBox")])
-                            ])
-else:
+if DRY_RUN:
     print("Skipping Create/Delete due to Dry Run")
+    print("----")
+    sys.exit()
 
+for record in to_create:
+    print("Creating", record)
+    zone = pdns.get_zone(record[3])
+    zone.create_records([
+                        powerdns.RRSet(
+                            record[0],
+                            record[1],
+                            [(record[2], False)],
+                            comments=[powerdns.Comment("NetBox")])
+                        ])
+
+print("----")
+
+for record in to_delete:
+    print("Deleting", record)
+    zone = pdns.get_zone(record[3])
+    zone.delete_records([
+                        powerdns.RRSet(
+                            record[0],
+                            record[1],
+                            [(record[2], False)],
+                            comments=[powerdns.Comment("NetBox")])
+                        ])
+    
 print("----")


### PR DESCRIPTION
This PR adds the following features:
- gitignore for venv etc.
- Allow Device Names to be specified as source for domains/IPs.
If this is activated, Devices are expected to have an FQDN, and their primary IPv4/IPv6 is used.
- DryRun: Only print records, but don't create/delete them.